### PR TITLE
fix: sed running out of mem for large files

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -451,7 +451,7 @@ process keep_only_pass {
 workflow prep_genome {
   take: reference_fasta
   main:
-    fasta_sort(reference_fasta) | (fasta_bwa_index & fasta_samtools_faidx & fasta_picard_dict )
+    reference_fasta | (fasta_bwa_index & fasta_samtools_faidx & fasta_picard_dict )
 
     genome_ch = fasta_bwa_index.out
       .combine(fasta_samtools_faidx.out)


### PR DESCRIPTION
sed is used in the genome.fasta sort, which turns out to be optional. Ergo we removed this step.