### PR TITLE
Add gatk haplotype params

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -46,6 +46,7 @@ def helpMsg() {
     --gatk_app              Link to gatk executable [default: '$gatk_app']
     --java_options          Java options for gatk [default:'${java_options}']
     --gatk_cluster_options  GATK cluster options [default:'${params.gatk_cluster_options}']
+    --gatk_HaplotypeCaller_params  Additional parameters to pass to GATK HaplotypeCaller [default:'${params.gatk_HaplotypeCaller_params}']
     
    Aligners:
     --bwamem2_app           Link to bwamem2 executable [default: '$bwamem2_app']
@@ -79,7 +80,8 @@ if(params.help){
 def parameters_valid = ['help','outdir',
   'genome','gtf','reads','reads_file','long_reads','invariant','seq',
   'singularity_img','docker_img','container_img',
-  'gatk_app','star_app','star_index_params','star_index_file','bwamem2_app','samtools_app','bedtools_app','datamash_app','vcftools_app',
+  'gatk_app','gatk_HaplotypeCaller_params',
+  'star_app','star_index_params','star_index_file','bwamem2_app','samtools_app','bedtools_app','datamash_app','vcftools_app',
   'pbmm2_app',
   'java_options','window','queueSize','queue-size','account', 'threads', 'gatk_cluster_options'] as Set
 

--- a/modules/local/DNAseq.nf
+++ b/modules/local/DNAseq.nf
@@ -149,7 +149,9 @@ process gatk_HaplotypeCaller {
     -R $genome_fasta \
     -I \$BAMFILES \
     -L $window \
-    --output ${window.replace(':','_')}.vcf
+    --output ${window.replace(':','_')}.vcf \
+    ${gatk_HaplotypeCaller_params}
+
   """
 
   stub:
@@ -178,7 +180,9 @@ process gatk_HaplotypeCaller_invariant {
     -R $genome_fasta \
     -I \$BAMFILES \
     -L $window \
-    --output ${bam.simpleName}_${window.replace(':','_')}.vcf
+    --output ${bam.simpleName}_${window.replace(':','_')}.vcf \
+    ${gatk_HaplotypeCaller_params}
+
   """
 
   stub:

--- a/modules/local/LongReadseq.nf
+++ b/modules/local/LongReadseq.nf
@@ -76,7 +76,9 @@ process gatk_HaplotypeCaller {
     -R $genome_fasta \
     -I ${bam} \
     -O ${bam.simpleName}_${window.replace(':','_')}_gvcf.gz \
-    -ERC GVCF
+    -ERC GVCF \
+    ${gatk_HaplotypeCaller_params}
+
   """
 
   stub:

--- a/modules/local/RNAseq.nf
+++ b/modules/local/RNAseq.nf
@@ -213,7 +213,9 @@ process gatk_HaplotypeCaller {
    -R $genome_fasta \
    -I \$BAMFILES \
    -L $window \
-   --output \${WIND}.vcf
+   --output \${WIND}.vcf \
+    ${gatk_HaplotypeCaller_params}
+
   """
   
   stub:

--- a/nextflow.config
+++ b/nextflow.config
@@ -28,6 +28,7 @@ params {
   docker_img = 'j23414/gatk4'
   container_img = 'docker://ghcr.io/aseetharam/gatk:master'
   gatk_app = 'gatk'
+  gatk_HaplotypeCaller_params = ''
   star_app = 'STAR'
   bwamem2_app = 'bwa-mem2'
   samtools_app = 'samtools'
@@ -57,6 +58,7 @@ env {
   star_index_file = params.star_index_file 
   bedtools_app = "$params.bedtools_app"
   gatk_app = "$params.gatk_app"
+  gatk_HaplotypeCaller_params = "$params.gatk_HaplotypeCaller_params"
   datamash_app = "$params.datamash_app"
   vcftools_app = "$params.vcftools_app"
   pbmm2_app = "$params.pbmm2_app"


### PR DESCRIPTION
Add a pass-through gatk HaplotypeCaller parameter. This allows for adjustment, such as for [polyploidy](https://gatk.broadinstitute.org/hc/en-us/articles/360035889691-Does-GATK-work-on-non-diploid-organisms-). 

This PR goes after: https://github.com/isugifNF/GATK/pull/9